### PR TITLE
gradle https_proxy

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -16,3 +16,5 @@
 systemProp.http.proxyHost=localhost
 org.gradle.jvmargs=-Xmx1536m
 systemProp.http.proxyPort=3128
+systemProp.https.proxyHost=localhost
+systemProp.https.proxyPort=3128


### PR DESCRIPTION
Set https proxy to be able to access repositories through an https proxies.